### PR TITLE
Add libgnutls30 to workaround nodesource expired cert

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -4,6 +4,11 @@ ENV PATH=$PATH:/node_modules/.bin
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE False
 ENV PIP_NO_BINARY=psycopg2
 
+# Install ligbnetls30, needed workaround for this issue to install nodesource:  https://github.com/nodesource/distributions/issues/1266
+RUN apt update && \
+    apt install libgnutls30
+
+# Install nodejs from nodesource
 RUN \
   echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
   echo "deb https://deb.nodesource.com/node_12.x stretch main" > /etc/apt/sources.list.d/nodesource.list && \

--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -29,6 +29,11 @@ ENV PATH=$PATH:/node_modules/.bin
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE False
 ENV PIP_NO_BINARY=psycopg2
 
+# Install ligbnetls30, needed workaround for this issue to install nodesource:  https://github.com/nodesource/distributions/issues/1266
+RUN apt update && \
+    apt install libgnutls30
+
+# Install nodejs from nodesource
 RUN \
   echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections && \
   echo "deb https://deb.nodesource.com/node_12.x stretch main" > /etc/apt/sources.list.d/nodesource.list && \


### PR DESCRIPTION
This PR adds `libgnutls30` package to workaround an expired cert (DST Root CA X3) that expired yesterday.

For more information, see:
- https://github.com/nodesource/distributions/issues/1266
- https://gitlab.com/gitlab-org/gitlab/-/issues/339842
- https://scotthelme.co.uk/lets-encrypt-old-root-expiration/
- https://letsencrypt.org/docs/dst-root-ca-x3-expiration-september-2021/

Will keep an eye on the above nodesource issue for a longer term fix, so hopefully we don't need to have this extra docker image layer forever, but for now this seems like the best temporary solution of the ones I've found in the articles & github issue above (for us).