### PR TITLE
Bump ttfiles version

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -14648,8 +14648,8 @@
       }
     },
     "ttfiles": {
-      "version": "git+https://github.com/texastribune/files.git#9b11499ac648f2d107940f67915ce138b53e609f",
-      "from": "git+https://github.com/texastribune/files.git#copy-id-button",
+      "version": "https://github.com/texastribune/files.git#a09e1e602d378b996a531bbd4a74c2a27622516d",
+      "from": "https://github.com/texastribune/files.git#v2.7.0",
       "requires": {
         "elements": "git+https://github.com/texastribune/elements.git#v1.1.8"
       }

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -5083,8 +5083,8 @@
       "dev": true
     },
     "elements": {
-      "version": "https://github.com/texastribune/elements.git#7b7cdcb8cb86cacc0b067156f7e8d339d89ca04f",
-      "from": "https://github.com/texastribune/elements.git#v1.1.7"
+      "version": "git+https://github.com/texastribune/elements.git#8e0e05b1955b6dec122a3ecfaed9ae2f81407530",
+      "from": "git+https://github.com/texastribune/elements.git#v1.1.8"
     },
     "elliptic": {
       "version": "6.5.4",
@@ -14648,10 +14648,10 @@
       }
     },
     "ttfiles": {
-      "version": "https://github.com/texastribune/files.git#8e90f5b47b08b0e82c7c4ec69533235d5875b32e",
-      "from": "https://github.com/texastribune/files.git#2.6.1",
+      "version": "git+https://github.com/texastribune/files.git#6ebd1b81b53aa09f38784cf9957c92dc12d86db8",
+      "from": "git+https://github.com/texastribune/files.git#copy-id-button",
       "requires": {
-        "elements": "https://github.com/texastribune/elements.git#v1.1.7"
+        "elements": "git+https://github.com/texastribune/elements.git#v1.1.8"
       }
     },
     "tty-browserify": {

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -14648,7 +14648,7 @@
       }
     },
     "ttfiles": {
-      "version": "git+https://github.com/texastribune/files.git#6ebd1b81b53aa09f38784cf9957c92dc12d86db8",
+      "version": "git+https://github.com/texastribune/files.git#9b11499ac648f2d107940f67915ce138b53e609f",
       "from": "git+https://github.com/texastribune/files.git#copy-id-button",
       "requires": {
         "elements": "git+https://github.com/texastribune/elements.git#v1.1.8"

--- a/node/package.json
+++ b/node/package.json
@@ -78,7 +78,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reframe.js": "^2.2.4",
-    "ttfiles": "https://github.com/texastribune/files.git#2.6.1",
+    "ttfiles": "git+https://github.com/texastribune/files.git#copy-id-button",
     "underscore": "^1.13.1",
     "validator": "^13.7.0"
   }

--- a/node/package.json
+++ b/node/package.json
@@ -78,7 +78,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reframe.js": "^2.2.4",
-    "ttfiles": "git+https://github.com/texastribune/files.git#copy-id-button",
+    "ttfiles": "https://github.com/texastribune/files.git#v2.7.0",
     "underscore": "^1.13.1",
     "validator": "^13.7.0"
   }


### PR DESCRIPTION
#### What's this PR do?

Bumps ttfiles version

texastribune PR: https://github.com/texastribune/texastribune/pull/4652
files PR: https://github.com/texastribune/files/pull/494

#### Why are we doing this? How does it help us?

Related to <https://github.com/texastribune/files/pull/494>

#### How should this be manually tested?

N/A

#### How should this change be communicated to end users?

N/A

#### Are there any smells or added technical debt to note?

No

#### What are the relevant tickets?

<https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwPxWENGdckjxRrP/recporrDL4PmEL3aT?blocks=hide>

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [ ] Added automated tests? *( )*
* [ ] Tested manually on mobile? *( )*
* [ ] Checked BrowserStack? *( )*
* [ ] Checked for performance implications? *( )*
* [ ] Checked accessibility? *( )*
* [ ] Checked for security implications? *( )*
* [ ] Updated the documentation/wiki? *(TODO separately from this PR)*

#### TODOs / next steps:

* [ ] Switch the version to a number.