### PR TITLE
Bump ttfiles and elements

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -5153,8 +5153,8 @@
       "dev": true
     },
     "elements": {
-      "version": "git+https://github.com/texastribune/elements.git#8e0e05b1955b6dec122a3ecfaed9ae2f81407530",
-      "from": "git+https://github.com/texastribune/elements.git#v1.1.8"
+      "version": "github:texastribune/elements#f2a6d60675990a6ff522e2eda4503f4272e6fbf9",
+      "from": "github:texastribune/elements#touch-dialog-buttons"
     },
     "elliptic": {
       "version": "6.5.4",
@@ -14717,10 +14717,10 @@
       }
     },
     "ttfiles": {
-      "version": "https://github.com/texastribune/files.git#a09e1e602d378b996a531bbd4a74c2a27622516d",
-      "from": "https://github.com/texastribune/files.git#v2.7.0",
+      "version": "git+https://github.com/texastribune/files.git#89efe730d098413f22775ff0dd5a2064f8aca579",
+      "from": "git+https://github.com/texastribune/files.git#elements-dialog-mobile",
       "requires": {
-        "elements": "git+https://github.com/texastribune/elements.git#v1.1.8"
+        "elements": "github:texastribune/elements#touch-dialog-buttons"
       }
     },
     "tty-browserify": {

--- a/node/package.json
+++ b/node/package.json
@@ -80,7 +80,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reframe.js": "^2.2.4",
-    "ttfiles": "https://github.com/texastribune/files.git#v2.7.0",
+    "ttfiles": "git+https://github.com/texastribune/files.git#elements-dialog-mobile",
     "underscore": "^1.13.1",
     "validator": "^13.7.0"
   }


### PR DESCRIPTION
#### What's this PR do?

Bumps ttfiles and elements dependencies

#### Why are we doing this? How does it help us?

See https://github.com/texastribune/Elements/pull/7

#### If applicable, what PR is this associated with in the texastribune repo?

Also see https://github.com/texastribune/Elements/pull/7 and https://github.com/texastribune/files/pull/508

#### Are there any smells or added technical debt to note?

No

#### What are the relevant tickets?

<https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwPxWENGdckjxRrP/recvM0Tfl61zz19kp?blocks=hide>

#### TODOs / next steps:

* [ ] Switch the version to a number.
