### PR TITLE
Update browserlist

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -3094,12 +3094,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001355",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001355.tgz",
-          "integrity": "sha512-Sd6pjJHF27LzCB7pT7qs+kuX2ndurzCzkpJl6Qct7LPSZ9jn0bkOA8mdgMgmqnQAWLVOOGjLpc+66V57eLtb1g==",
-          "dev": true
-        },
         "electron-to-chromium": {
           "version": "1.4.158",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.158.tgz",
@@ -3715,9 +3709,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001332",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001332.tgz",
-      "integrity": "sha512-10T30NYOEQtN6C11YGg411yebhvpnC6Z102+B95eAsN0oB6KUs01ivE8u+G6FMIRtIrVlYXhL+LUwQ3/hXwDWw==",
+      "version": "1.0.30001429",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001429.tgz",
+      "integrity": "sha512-511ThLu1hF+5RRRt0zYCf2U2yRr9GPF6m5y90SBCWsvSoYoW7yAGlv/elyPaNfvGCkp6kj/KFZWU0BMA69Prsg==",
       "dev": true
     },
     "capture-exit": {
@@ -10704,12 +10698,6 @@
             "node-releases": "^2.0.6",
             "update-browserslist-db": "^1.0.9"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001422",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001422.tgz",
-          "integrity": "sha512-hSesn02u1QacQHhaxl/kNMZwqVG35Sz/8DgvmgedxSH8z9UUpcDYSPYgsj3x5dQNRcNp6BwpSfQfVzYUTm+fog==",
-          "dev": true
         },
         "electron-to-chromium": {
           "version": "1.4.284",


### PR DESCRIPTION
#### What's this PR do?

Updates our browserlist, which is important to do from time to time.

#### Why are we doing this? How does it help us?

Clears this warning when webpack is run:

```
Browserslist: caniuse-lite is outdated. Please run:
  npx browserslist@latest --update-db
  Why you should do it regularly: https://github.com/browserslist/browserslist#browsers-data-updating
```

#### If applicable, what PR is this associated with in the texastribune repo?

https://github.com/texastribune/tt-docker-base/pull/660

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

#### TODOs / next steps:

* [ ] *your TODO here*
