### PR TITLE
Upgrade ttfiles to 2.8.2

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -11668,6 +11668,11 @@
         }
       }
     },
+    "remove-accents": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.3.tgz",
+      "integrity": "sha512-bwzzFccF6RgWWt+KrcEpCDMw9uCwz5GCdyo+r4p2hu6PhqtlEMOXEO0uPAw6XmVYAnODxHaqLanhUY1lqmsNFw=="
+    },
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -13338,8 +13343,11 @@
       }
     },
     "ttfiles": {
-      "version": "git+https://github.com/texastribune/files.git#7066ee9fad9fbe82fd3e907f9a65e0b281c87fd4",
-      "from": "git+https://github.com/texastribune/files.git#v2.8.1"
+      "version": "git+https://github.com/texastribune/files.git#3257b710f93a90029d674ccb7e5d9ad16989f9cc",
+      "from": "git+https://github.com/texastribune/files.git#v2.8.2",
+      "requires": {
+        "remove-accents": "^0.4.3"
+      }
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/node/package.json
+++ b/node/package.json
@@ -79,7 +79,7 @@
     "redux": "^4.0.0",
     "redux-thunk": "^2.3.0",
     "reframe.js": "^2.2.4",
-    "ttfiles": "git+https://github.com/texastribune/files.git#v2.8.1",
+    "ttfiles": "git+https://github.com/texastribune/files.git#v2.8.2",
     "underscore": "^1.13.1",
     "validator": "^13.7.0"
   }


### PR DESCRIPTION
#### What's this PR do?

Upgrades ttfiles to the latest version, [v2.8.2](https://github.com/texastribune/files/releases/tag/v2.8.2), which now removes the accents from the filenames of uploaded files, converting them to their corresponding non-accented ASCII characters.

#### Why are we doing this? How does it help us?

This change was requested by the photo dept. See [here](https://github.com/texastribune/files/pull/609) for more details.

#### If applicable, what PR is this associated with in the texastribune repo?

#### Are there any smells or added technical debt to note?

#### What are the relevant tickets?

https://airtable.com/appyo1zuQd8f4hBVx/tbloNZu8GkM52NKFR/viwKqLrNFM17Lq15R/rechCDx9r7wA8pHOu?blocks=hide

#### TODOs / next steps:

* [ ] *your TODO here*
